### PR TITLE
Adding chunking to the coingecko price fetching

### DIFF
--- a/src/utils/array.spec.ts
+++ b/src/utils/array.spec.ts
@@ -1,0 +1,48 @@
+// https://stackoverflow.com/questions/58999086/cypress-causing-type-errors-in-jest-assertions
+import { expect } from '@jest/globals';
+import { chunk } from './array';
+
+describe('utils/array', () => {
+  describe('chunk', () => {
+    type TestArgs = {
+      arr: string[];
+      chunkSize: number;
+      expectedResult: string[][];
+    };
+
+    const testParams: TestArgs[] = [
+      {
+        arr: [],
+        chunkSize: 1,
+        expectedResult: []
+      },
+      {
+        arr: ['a', 'b', 'c'],
+        chunkSize: 1,
+        expectedResult: [['a'], ['b'], ['c']]
+      },
+      {
+        arr: ['a', 'b', 'c'],
+        chunkSize: 2,
+        expectedResult: [['a', 'b'], ['c']]
+      },
+      {
+        arr: ['a', 'b', 'c'],
+        chunkSize: 3,
+        expectedResult: [['a', 'b', 'c']]
+      },
+      {
+        arr: ['a', 'b', 'c'],
+        chunkSize: 4,
+        expectedResult: [['a', 'b', 'c']]
+      }
+    ];
+
+    testParams.forEach((testParam) => {
+      it(JSON.stringify(testParam), () => {
+        const actualResult = chunk(testParam.arr, testParam.chunkSize);
+        expect(actualResult).toEqual(testParam.expectedResult);
+      });
+    });
+  });
+});

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -1,0 +1,3 @@
+export function chunk<T>(arr: T[], size: number): T[][] {
+  return Array.from({ length: Math.ceil(arr.length / size) }, (_, i) => arr.slice(i * size, i * size + size));
+}


### PR DESCRIPTION
- Now when fetching from coingecko chuck the requests by default in 20 size chunks