### PR TITLE
Making the RPC lookup more resilient with caching and failover

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,24 @@
 # Introduction
 
-The [@ichidao/ichi-sdk](https://www.npmjs.com/package/@ichidao/ichi-sdk) is a library which used across various ICHI DAO applications.
+The [@ichidao/ichi-sdk](https://www.npmjs.com/package/@ichidao/ichi-sdk) is a Typescript library which used across various ICHI DAO applications.
 
 ## Local development
 
 While working with this repository locally, if you want to test it's usage in another app run `npm link` in the root of this repo, so `cd /path/to/ichi-sdk && npm link`.  Then navigate to the project you want to use the `ichi-sdk` in, let's say it's `myproject`, so `cd /path/to/myproject`, then run `npm link @ichidao/ichi-sdk`.
 
 In the project using `@ichidao/ichi-sdk` once you are done developing with the linked `ichi-sdk` and you've published the latest version of the `ichi-sdk` then you can `rm -rf node_modules/@ichidao/ichi-sdk && npm i` to install the latest published version.
+
+### Building
+
+`npm build`
+
+### Testing
+
+`npm test`
+
+### Linting
+
+`npm lint`
 
 ## Publishing to NPM
 
@@ -15,8 +27,3 @@ npm install -g np
 npm login
 np
 ```
-
-## TODO
-
-- Use Rollup or something similar to ensure treeshakability: https://dev.to/lukasbombach/how-to-write-a-tree-shakable-component-library-4ied
-- Consider changing src to lib so that importing looks more natural

--- a/src/constants/oracles.spec.ts
+++ b/src/constants/oracles.spec.ts
@@ -1,6 +1,5 @@
 import { expect } from '@jest/globals';
 import { ChainId } from '../crypto/networks';
-import { getAddress } from '../constants/addresses';
 import { AddressName } from '../enums/addressName';
 import { ORACLES, getOracleAddress, getAllOneTokenOracles } from './oracles';
 import { OracleName } from '../enums/oracleName';
@@ -17,8 +16,8 @@ describe('constants/addresses', () => {
       {
         name: OracleName.ICHI_ORACLE,
         chainId: ChainId.Mainnet,
-        expectedAddress: ORACLES[OracleName.ICHI_ORACLE][ChainId.Mainnet],
-      },
+        expectedAddress: ORACLES[OracleName.ICHI_ORACLE][ChainId.Mainnet]
+      }
     ];
 
     testParams.forEach((testParam) => {

--- a/src/constants/oracles.ts
+++ b/src/constants/oracles.ts
@@ -3,8 +3,6 @@ import { PartialRecord } from '../types/common';
 import { getOneTokenFactoryContract } from '../utils/contracts';
 import { getProvider } from '../crypto/providers';
 import { OracleName, OracleNames } from '../enums/oracleName';
-import { TokenName } from '../enums/tokenName';
-import { getToken } from './tokens';
 import { OneTokenFactory } from '../generated';
 import { getAddress } from './addresses';
 import { AddressName } from '../enums/addressName';
@@ -16,10 +14,13 @@ type OracleMapping = {
 // TODO: I think we can totally remove this and merge it into the TOKENS?  So here are some overlap here, really we want
 // tokens to be in tokens.ts and other contracts are fine to be in here...
 export const ORACLES: OracleMapping = {
-  [OracleName.ICHI_ORACLE]: { [ChainId.Mainnet]: '0xD41EA28e17BD06136c416cA942fB997122138139' },
+  [OracleName.ICHI_ORACLE]: { [ChainId.Mainnet]: '0xD41EA28e17BD06136c416cA942fB997122138139' }
 };
 
-export async function getAllOneTokenOracles(oneTokenFactoryName: AddressName, chainId: ChainId): Promise<Record<string, string[]>> {
+export async function getAllOneTokenOracles(
+  oneTokenFactoryName: AddressName,
+  chainId: ChainId
+): Promise<Record<string, string[]>> {
   let oneTokenToOracle = {};
 
   const ichiVaultFactory = await getOneTokenFactoryInstance(oneTokenFactoryName, chainId);
@@ -34,11 +35,12 @@ export async function getAllOneTokenOracles(oneTokenFactoryName: AddressName, ch
 }
 
 export async function getOneTokenOracles(
-  oneTokenAddress: string, 
-  chainId: ChainId, 
-  ichiVaultFactoryContract?: OneTokenFactory, 
-  oneTokenFactoryName?: AddressName): Promise<string[]> {
-  let ichiVaultFactory;
+  oneTokenAddress: string,
+  chainId: ChainId,
+  ichiVaultFactoryContract?: OneTokenFactory,
+  oneTokenFactoryName?: AddressName
+): Promise<string[]> {
+  let ichiVaultFactory: OneTokenFactory;
   if (!ichiVaultFactoryContract) {
     if (!oneTokenFactoryName) {
       throw 'Cannot make instance of OneToken Factory - Name not provided';
@@ -59,7 +61,10 @@ export async function getOneTokenOracles(
   return oneTokenToOracle;
 }
 
-async function getOneTokenFactoryInstance(oneTokenFactoryName: AddressName, chainId: ChainId): Promise<OneTokenFactory> {
+async function getOneTokenFactoryInstance(
+  oneTokenFactoryName: AddressName,
+  chainId: ChainId
+): Promise<OneTokenFactory> {
   const provider = await getProvider(chainId);
   if (!provider) {
     throw Error('Could not connect with provider');

--- a/src/crypto/networks.ts
+++ b/src/crypto/networks.ts
@@ -53,7 +53,7 @@ export type SupportedNetworkList = {
 };
 
 export const generateIconUrl = (chainId: ChainId, ext: 'png' | 'svg') => {
-  return EnvUtils.EnvValue.CHAIN_SRC?.replace('[chainid]', chainId.toString()).replace('[ext]', ext);
+  return EnvUtils.getValue(EnvUtils.EnvName.CHAIN_SRC)?.replace('[chainid]', chainId.toString()).replace('[ext]', ext);
 };
 
 export const SUPPORTED_NETWORKS: SupportedNetworkList = {

--- a/src/crypto/providers.spec.ts
+++ b/src/crypto/providers.spec.ts
@@ -11,7 +11,7 @@ describe('providers', () => {
     beforeEach(() => {
       jest.resetModules(); // this is important - it clears the cache
       process.env = { ...env };
-      setRpcCacheUpdateInterval(1 * 1000);
+      setRpcCacheUpdateInterval(0.5 * 1000);
     });
 
     afterEach(() => {

--- a/src/crypto/providers.spec.ts
+++ b/src/crypto/providers.spec.ts
@@ -1,0 +1,66 @@
+import { expect } from '@jest/globals';
+import { ChainId } from '../crypto/networks';
+import { getProvider, providerCache, resetProviderCache, setRpcCacheUpdateInterval } from './providers';
+
+// npx jest providers.spec.ts
+// npm test -- providers.spec.ts
+describe('providers', () => {
+  describe('getProvider', () => {
+    const env = process.env;
+
+    beforeEach(() => {
+      jest.resetModules(); // this is important - it clears the cache
+      process.env = { ...env };
+      setRpcCacheUpdateInterval(1 * 1000);
+    });
+
+    afterEach(() => {
+      process.env = env;
+      resetProviderCache();
+      setRpcCacheUpdateInterval(30 * 1000);
+    });
+
+    type TestArgs = {
+      chainId: ChainId;
+      rpcUrls: string;
+      expectedRpcUrl?: string;
+    };
+
+    const testParams: TestArgs[] = [
+      {
+        chainId: ChainId.Mainnet,
+        rpcUrls: `https://internal.does.not.exit,http://foo.internal:8545,https://cloudflare-eth.com`,
+        expectedRpcUrl: 'https://cloudflare-eth.com'
+      },
+      {
+        chainId: ChainId.Mainnet,
+        rpcUrls: `https://cloudflare-eth.com,http://foo.internal:8545`,
+        expectedRpcUrl: 'https://cloudflare-eth.com'
+      }
+    ];
+
+    testParams.forEach((testParam) => {
+      it(JSON.stringify(testParam), async () => {
+        process.env.MAINNET_RPC_HOSTS = testParam.rpcUrls;
+        // Get the initial provider which will set that provider in the cache
+        const actualResult = await getProvider(testParam.chainId);
+        // Verify the rpc url matches the one that was able to resolve on the network
+        expect(actualResult?.connection.url).toEqual(testParam.expectedRpcUrl);
+        // At this point we have no cache hit as we've only set the cache
+        expect(providerCache[ChainId.Mainnet].cacheHit).toEqual(0);
+        // Accessing the provider again should result in a cache hit
+        await getProvider(testParam.chainId);
+        // Now expect a cache hit
+        expect(providerCache[ChainId.Mainnet].cacheHit).toEqual(1);
+        // Store the last updated so we can verify it's been updated below
+        const prevCacheDate = providerCache[ChainId.Mainnet].lastUdated;
+        // Wait 1 seconds to give time for a cache invalidation
+        await new Promise((r) => setTimeout(r, 1000));
+        // Get the provider again which will force a cache update
+        await getProvider(testParam.chainId);
+        // Excect the cache to be updated by checking the lastUpdated date
+        expect(providerCache[ChainId.Mainnet].lastUdated).toBeGreaterThan(prevCacheDate);
+      });
+    });
+  });
+});

--- a/src/crypto/providers.ts
+++ b/src/crypto/providers.ts
@@ -194,7 +194,6 @@ export const getProvider = async (chainId: ChainId): Promise<Optional<JsonRpcPro
     const lastUpdated = providerCache[chainId]?.lastUdated;
     // If it has been, clear the cache for this chain the re-establish the provider
     if (lastUpdated && Date.now() - lastUpdated > RPC_CACHE_UPDATE_INTERVAL) {
-      console.log(`[REMOVE] CACHE UPDATED!!!`);
       setCachedProvider(chainId, undefined);
       return getProvider(chainId);
     }

--- a/src/external/coinMarketCap.ts
+++ b/src/external/coinMarketCap.ts
@@ -1,20 +1,23 @@
 import CoinMarketCap from 'coinmarketcap-api';
-import 
-{   QuotePriceData, 
-    CoinMarketCapTokenInfoResponse } from '../models/coinMarketCap';
+import { QuotePriceData, CoinMarketCapTokenInfoResponse } from '../models/coinMarketCap';
 import { EnvUtils } from '../utils/env';
 import { Optional } from '../types/optional';
 
-const cmcClient = new CoinMarketCap(EnvUtils.EnvValue.CMC_API_KEY);
+const cmcClient = new CoinMarketCap(EnvUtils.getValue(EnvUtils.EnvName.CMC_API_KEY));
 
-export async function getTokenPriceFromCoinMarketCap(tokenName: string, denominationName: string = 'USD'): Promise<Optional<QuotePriceData>> {
-    let tokenInfo = await getTokenInfoFromCoinMarketCap(tokenName);
-    if (!tokenInfo) {
-        throw new Error(`Error calling coinmarketcap for ${tokenName}`);
-    }
-    return tokenInfo.data[tokenName].quote[denominationName];
+export async function getTokenPriceFromCoinMarketCap(
+  tokenName: string,
+  denominationName: string = 'USD'
+): Promise<Optional<QuotePriceData>> {
+  let tokenInfo = await getTokenInfoFromCoinMarketCap(tokenName);
+  if (!tokenInfo) {
+    throw new Error(`Error calling coinmarketcap for ${tokenName}`);
+  }
+  return tokenInfo.data[tokenName].quote[denominationName];
 }
 
-export async function getTokenInfoFromCoinMarketCap(tokenName: string): Promise<Optional<CoinMarketCapTokenInfoResponse>> {
-    return cmcClient.getQuotes({ symbol: [tokenName] });
+export async function getTokenInfoFromCoinMarketCap(
+  tokenName: string
+): Promise<Optional<CoinMarketCapTokenInfoResponse>> {
+  return cmcClient.getQuotes({ symbol: [tokenName] });
 }

--- a/src/models/providerCache.ts
+++ b/src/models/providerCache.ts
@@ -1,0 +1,8 @@
+import { JsonRpcProvider } from '@ethersproject/providers';
+
+export type ProviderCache = {
+  provider?: JsonRpcProvider;
+  lastUdated: number;
+  cacheHit: number;
+  cacheMiss: number;
+};

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -12,7 +12,7 @@ export namespace EnvUtils {
     BSC_RPC_HOSTS = 'BSC_RPC_HOSTS',
     POLYGON_RPC_HOSTS = 'POLYGON_RPC_HOSTS',
     MUMBAI_RPC_HOSTS = 'MUMBAI_RPC_HOSTS',
-    CMC_API_KEY = 'CMC_API_KEY',
+    CMC_API_KEY = 'CMC_API_KEY'
   }
 
   export enum GatsbyEnvName {
@@ -25,7 +25,7 @@ export namespace EnvUtils {
     GATSBY_BSC_RPC_HOSTS = 'GATSBY_BSC_RPC_HOSTS',
     GATSBY_POLYGON_RPC_HOSTS = 'GATSBY_POLYGON_RPC_HOSTS',
     GATSBY_MUMBAI_RPC_HOSTS = 'GATSBY_MUMBAI_RPC_HOSTS',
-    GATSBY_CMC_API_KEY = 'GATSBY_CMC_API_KEY',
+    GATSBY_CMC_API_KEY = 'GATSBY_CMC_API_KEY'
   }
 
   export type EnvNameKey = keyof typeof EnvName;
@@ -56,28 +56,28 @@ export namespace EnvUtils {
 
   // Note that in testing ultimately we should getValue to dynamically resolve the process.env and not
   // rely on these EnvValue, these are more quick accesssors for the main app
-  export const EnvValue: PartialRecord<EnvNameKey, string> = {
-    [EnvUtils.EnvName.ALCHEMY_ID]: EnvUtils.getValue(EnvName.ALCHEMY_ID),
-    [EnvUtils.EnvName.INFURA_ID]: EnvUtils.getValue(EnvName.INFURA_ID),
-    [EnvUtils.EnvName.CHAIN_SRC]: EnvUtils.getValue(EnvName.CHAIN_SRC),
-    [EnvUtils.EnvName.CMC_API_KEY]: EnvUtils.getValue(EnvName.CMC_API_KEY),
-  };
+  // export const EnvValue: PartialRecord<EnvNameKey, string> = {
+  //   [EnvUtils.EnvName.ALCHEMY_ID]: EnvUtils.getValue(EnvName.ALCHEMY_ID),
+  //   [EnvUtils.EnvName.INFURA_ID]: EnvUtils.getValue(EnvName.INFURA_ID),
+  //   [EnvUtils.EnvName.CHAIN_SRC]: EnvUtils.getValue(EnvName.CHAIN_SRC),
+  //   [EnvUtils.EnvName.CMC_API_KEY]: EnvUtils.getValue(EnvName.CMC_API_KEY)
+  // };
 
-  export const EnvValues: PartialRecord<EnvNameKey, string[]> = {
-    [EnvUtils.EnvName.MAINNET_RPC_HOSTS]: EnvUtils.getValues(EnvName.MAINNET_RPC_HOSTS),
-    [EnvUtils.EnvName.KOVAN_RPC_HOSTS]: EnvUtils.getValues(EnvName.KOVAN_RPC_HOSTS),
-    [EnvUtils.EnvName.GOERLI_RPC_HOSTS]: EnvUtils.getValues(EnvName.GOERLI_RPC_HOSTS),
-    [EnvUtils.EnvName.BSC_RPC_HOSTS]: EnvUtils.getValues(EnvName.BSC_RPC_HOSTS),
-    [EnvUtils.EnvName.POLYGON_RPC_HOSTS]: EnvUtils.getValues(EnvName.POLYGON_RPC_HOSTS),
-    [EnvUtils.EnvName.MUMBAI_RPC_HOSTS]: EnvUtils.getValues(EnvName.MUMBAI_RPC_HOSTS)
-  };
+  // export const EnvValues: PartialRecord<EnvNameKey, string[]> = {
+  //   [EnvUtils.EnvName.MAINNET_RPC_HOSTS]: EnvUtils.getValues(EnvName.MAINNET_RPC_HOSTS),
+  //   [EnvUtils.EnvName.KOVAN_RPC_HOSTS]: EnvUtils.getValues(EnvName.KOVAN_RPC_HOSTS),
+  //   [EnvUtils.EnvName.GOERLI_RPC_HOSTS]: EnvUtils.getValues(EnvName.GOERLI_RPC_HOSTS),
+  //   [EnvUtils.EnvName.BSC_RPC_HOSTS]: EnvUtils.getValues(EnvName.BSC_RPC_HOSTS),
+  //   [EnvUtils.EnvName.POLYGON_RPC_HOSTS]: EnvUtils.getValues(EnvName.POLYGON_RPC_HOSTS),
+  //   [EnvUtils.EnvName.MUMBAI_RPC_HOSTS]: EnvUtils.getValues(EnvName.MUMBAI_RPC_HOSTS)
+  // };
 
   export function printEnvironment() {
-    for (let envName in EnvValue) {
-      console.log(`env:${envName}:${EnvValue[envName]} `);
+    for (let envName in EnvName) {
+      console.log(`env:${envName}:${getValue(envName as EnvName)} `);
     }
-    for (let envName in EnvValues) {
-      console.log(`env:${envName}:${EnvValues[envName]} `);
+    for (let envName in EnvName) {
+      console.log(`env:${envName}:${getValues(envName as EnvName)} `);
     }
   }
 
@@ -107,9 +107,7 @@ export namespace EnvUtils {
     }
 
     if (!EnvUtils.isDefined(EnvUtils.EnvName.CMC_API_KEY)) {
-      console.warn(
-        'It may be necessary to set the environment variable "CMC_API_KEY"'
-      );
+      console.warn('It may be necessary to set the environment variable "CMC_API_KEY"');
       // return false;
     }
 


### PR DESCRIPTION
* Implemented a proper failover and caching for the provider.  When calling getProvider it iterates through the list of rpc urls defined in the respected env vars and does a dns lookup on the hostname then caches and returns the first working one.  After a default of 30 seconds, the next call to getProvider will re-establish the first working rpc provider and re-cache. 